### PR TITLE
Relax the text requirement.

### DIFF
--- a/content-store.cabal
+++ b/content-store.cabal
@@ -44,7 +44,7 @@ library
                      mtl >= 2.2.1 && < 2.3,
                      resourcet >= 1.1.9 && < 1.2,
                      temporary >= 1.2.1.1 && < 1.3.0.0,
-                     text >= 1.2.2.2 && < 1.3,
+                     text >= 1.2.2.0 && < 1.3,
                      transformers >= 0.5.2.0 && < 0.6.0.0,
                      transformers-base >= 0.4.4 && < 0.5.0,
                      unix >= 2.7.2.1 && < 2.8.0.0


### PR DESCRIPTION
There's nothing in particular we need from the newer text releases, and
Fedora currently has an older version of text packaged.