### PR TITLE
Relax more dependency versions.

### DIFF
--- a/content-store.cabal
+++ b/content-store.cabal
@@ -28,7 +28,7 @@ library
                      Data.ContentStore.Config,
                      Data.ContentStore.Digest
 
-  build-depends:     aeson >= 1.2.2.0 && < 1.3.0.0,
+  build-depends:     aeson >= 1.0.0.0 && < 1.3.0.0,
                      base >= 4.9 && < 5.0,
                      bytestring >= 0.10 && < 0.11,
                      cond >= 0.4.1.1 && < 0.5.0.0,
@@ -39,11 +39,11 @@ library
                      directory >= 1.3.0.0 && < 1.4.0.0,
                      filepath >= 1.4.1.1 && < 1.5.0.0,
                      htoml >= 1.0.0.0 && < 1.1.0.0,
-                     monad-control >= 1.0.2.2 && < 1.1.0.0,
+                     monad-control >= 1.0.1.0 && < 1.1.0.0,
                      memory >= 0.14.3 && < 0.15.0,
                      mtl >= 2.2.1 && < 2.3,
                      resourcet >= 1.1.9 && < 1.2,
-                     temporary >= 1.2.1.1 && < 1.3.0.0,
+                     temporary >= 1.2.0.4 && < 1.3.0.0,
                      text >= 1.2.2.0 && < 1.3,
                      transformers >= 0.5.2.0 && < 0.6.0.0,
                      transformers-base >= 0.4.4 && < 0.5.0,


### PR DESCRIPTION
We don't require any of the new functionality in temporary or aeson, and
the newer versions of monad-control are just documentation changes.

This should be it, it can now build against F26 packages.