### PR TITLE
Add more configuration for OStree repos

### DIFF
--- a/Data/ContentStore/Config.hs
+++ b/Data/ContentStore/Config.hs
@@ -84,5 +84,7 @@ readConfig path = do
 writeConfig :: FilePath -> Config -> IO ()
 writeConfig path Config{..} = TIO.writeFile path configText
  where
-    configText = T.concat ["compressed = ", if confCompressed then "true" else "false", "\n",
+    configText = T.concat ["[core]",
+                           "repo_version = 1",
+                           "compressed = ", if confCompressed then "true" else "false", "\n",
                            "hash = \"", confHash, "\"\n"]


### PR DESCRIPTION
ostree requires that the `config' file has the
[core] section identifier and the repo_version attributes.

Otherwise it gives errors like:

Couldn't parse config file: Key file does not start with a group

or

error: Key file does not have key 'repo_version' in group 'core'

This in turn causes test failures for bdcs, see
https://github.com/weldr/bdcs/issues/116

@clumens even with the changes in this PR applied to the existing config file I still get an error:
```
# ostree --repo=./export.repo refs
error: openat: No such file or directory
```

from what I can tell openat.h is a dynamically generated file inside the ostree sources.
