### PR TITLE
Install hlint and hpc-coveralls at the same time as everything else.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,7 @@ sandbox:
 	[ -d .cabal-sandbox ] || cabal sandbox init && cabal update
 
 hlint: sandbox
-	[ -x .cabal-sandbox/bin/happy ] || cabal install happy
-	[ -x .cabal-sandbox/bin/hlint ] || cabal install hscolour==1.24.2 hlint
-	cabal exec hlint .
+	[ -x .cabal-sandbox/bin/hlint ] && cabal exec hlint .
 
 tests: sandbox
 	cabal install --dependencies-only --enable-tests --force-reinstalls
@@ -12,8 +10,7 @@ tests: sandbox
 	cabal build
 	cabal test --show-details=always
 
-ci: hlint tests
+ci: tests hlint
 
 ci_after_success:
-	[ -x .cabal-sandbox/bin/hpc-coveralls ] || cabal install hpc-coveralls
-	cabal exec hpc-coveralls -- --display-report spec
+	[ -x .cabal-sandbox/bin/hpc-coveralls ] && cabal exec hpc-coveralls -- --display-report spec

--- a/content-store.cabal
+++ b/content-store.cabal
@@ -64,6 +64,8 @@ test-suite spec
                     conduit-combinators >= 1.1.0 && < 1.3,
                     directory >= 1.3.0.0 && < 1.4.0.0,
                     filepath >= 1.4.1.1 && < 1.5.0.0,
+                    hlint,
+                    hpc-coveralls,
                     hspec == 2.*,
                     memory >= 0.14.3 && < 0.15.0,
                     mtl >= 2.2.1 && < 2.3,


### PR DESCRIPTION
This turns them into build dependencies for the test-suite target.
Elsewhere, we are having a problem where hlint gets installed first,
populating the sandbox with versions of its dependencies that satisfy
hlint but may conflict with the library target.  Then when the library
is built, its dependencies may not be satisfiable given the earlier
choices made when installing hlint.

I have also removed happy as a requirement - nothing appears to use it.