### PR TITLE
Don't try to install and run hpc-coveralls and hlint from the sandbox.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - wget https://haskell.org/platform/download/8.0.2/haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
   - tar -xzvf ./haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
   - sudo ./install-haskell-platform.sh
-  - travis_retry cabal update && cabal install hlint hpc-coveralls
+  - travis_retry cabal update && cabal --ignore-sandbox install hlint hpc-coveralls
 
 script:
   - make ci

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 sandbox:
-	[ -d .cabal-sandbox ] || cabal sandbox init && cabal update
+	[ -d .cabal-sandbox ] && cabal sandbox delete && cabal clean
+	cabal sandbox init && cabal update
 
 hlint: sandbox
 	hlint .

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,7 @@ sandbox:
 	[ -d .cabal-sandbox ] || cabal sandbox init && cabal update
 
 hlint: sandbox
-	[ -x .cabal-sandbox/bin/happy ] || cabal install happy
-	[ -x .cabal-sandbox/bin/hlint ] || cabal install hscolour==1.24.2 hlint
-	cabal exec hlint .
+	hlint .
 
 tests: sandbox
 	cabal install --dependencies-only --enable-tests --force-reinstalls
@@ -12,8 +10,7 @@ tests: sandbox
 	cabal build
 	cabal test --show-details=always
 
-ci: hlint tests
+ci: tests hlint
 
 ci_after_success:
-	[ -x .cabal-sandbox/bin/hpc-coveralls ] || cabal install hpc-coveralls
-	cabal exec hpc-coveralls -- --display-report spec
+	hpc-coveralls --display-report spec


### PR DESCRIPTION
They're already being installed globally by .travis.yml and have the right
versions of their dependencies.  They don't also need to be installed into
the sandbox where they can influence the versions of dependencies that
will be installed for the content-store library.