### PR TITLE
Don't try to install and run hpc-coveralls and hlint from the sandbox.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - tar -xzvf ./haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
   - sudo ./install-haskell-platform.sh
   - travis_retry cabal update && cabal --ignore-sandbox install hlint hpc-coveralls
+  - export PATH=$HOME/.cabal/bin:$PATH
 
 script:
   - make ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - wget https://haskell.org/platform/download/8.0.2/haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
   - tar -xzvf ./haskell-platform-8.0.2-unknown-posix--minimal-x86_64.tar.gz
   - sudo ./install-haskell-platform.sh
-  - travis_retry cabal update && cabal install hlint hpc-coveralls
+  - travis_retry cabal update && cabal --ignore-sandbox install hlint hpc-coveralls
 
 script:
   - make ci

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,7 @@ sandbox:
 	[ -d .cabal-sandbox ] || cabal sandbox init && cabal update
 
 hlint: sandbox
-	[ -x .cabal-sandbox/bin/happy ] || cabal install happy
-	[ -x .cabal-sandbox/bin/hlint ] || cabal install hscolour==1.24.2 hlint
-	cabal exec hlint .
+	~/.cabal/bin/hlint .
 
 tests: sandbox
 	cabal install --dependencies-only --enable-tests --force-reinstalls
@@ -12,8 +10,7 @@ tests: sandbox
 	cabal build
 	cabal test --show-details=always
 
-ci: hlint tests
+ci: tests hlint
 
 ci_after_success:
-	[ -x .cabal-sandbox/bin/hpc-coveralls ] || cabal install hpc-coveralls
-	cabal exec hpc-coveralls -- --display-report spec
+	~/.cabal/bin/hpc-coveralls --display-report spec

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,12 @@ sandbox:
 	[ -d .cabal-sandbox ] || cabal sandbox init && cabal update
 
 hlint: sandbox
-	~/.cabal/bin/hlint .
+	if [ -z "$$(which hlint)" ]; then \
+		echo hlint not found in PATH - install it; \
+		exit 1; \
+	else \
+		hlint .; \
+	fi
 
 tests: sandbox
 	cabal install --dependencies-only --enable-tests --force-reinstalls
@@ -13,4 +18,9 @@ tests: sandbox
 ci: tests hlint
 
 ci_after_success:
-	~/.cabal/bin/hpc-coveralls --display-report spec
+	if [ -z "$$(which hpc-coveralls)" ]; then \
+		echo hpc-coveralls not found in PATH - install it; \
+		exit 1; \
+	else \
+		hpc-coveralls --display-report spec; \
+	fi


### PR DESCRIPTION
They're already being installed globally by .travis.yml and have the right
versions of their dependencies.  They don't also need to be installed into
the sandbox where they can influence the versions of dependencies that
will be installed for the content-store library.