### PR TITLE
Add dist target to build a cabal tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,13 @@ tests: sandbox
 	cabal build
 	cabal test --show-details=always
 
+dist: sandbox
+	cabal configure
+	cabal sdist
+
 ci: tests hlint
 
-ci_after_success:
+ci_after_success: dist
 	if [ -z "$$(which hpc-coveralls)" ]; then \
 		echo hpc-coveralls not found in PATH - install it; \
 		exit 1; \


### PR DESCRIPTION
and do so on ci_after_success. These tarballs will end up in dist/
and we're going to use them in testing dependent software like
bdcs.