### PR TITLE
Link to latest tarball for Jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ tests: sandbox
 dist: sandbox
 	cabal configure
 	cabal sdist
+	ln dist/content-store-*.tar.gz dist/content-store-latest.tar.gz
 
 ci: tests hlint
 


### PR DESCRIPTION
upload of artifacts is fine with wildcards but copyartifact
needs the exact name.